### PR TITLE
feat: JSON Reporter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,4 +32,3 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./.cover/coverage.out
-          fail_ci_if_error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,3 +32,4 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./.cover/coverage.out
+          fail_ci_if_error: true

--- a/cmd/pint/lint.go
+++ b/cmd/pint/lint.go
@@ -123,8 +123,7 @@ func report(summary reporter.Summary, reporters *config.Reporters) error {
 	if reporters != nil && reporters.JSON != nil {
 		if reporters.JSON != nil {
 			r := reporter.NewJSONReporter(reporters.JSON.Path)
-			if err := r.Submit(summary.Reports()); err != nil { return err; }
-			if err != nil {
+			if err := r.Submit(summary.Reports()); err != nil {
 				return err
 			}
 		}

--- a/cmd/pint/lint.go
+++ b/cmd/pint/lint.go
@@ -120,11 +120,13 @@ func actionLint(c *cli.Context) error {
 }
 
 func report(summary reporter.Summary, reporters *config.Reporters) error {
-	if reporters.JSON != nil {
-		r := reporter.NewJSONReporter(reporters.JSON.Path)
-		err := r.Submit(summary.Reports())
-		if err != nil {
-			return err
+	if reporters != nil {
+		if reporters.JSON != nil {
+			r := reporter.NewJSONReporter(reporters.JSON.Path)
+			err := r.Submit(summary.Reports())
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/cmd/pint/lint.go
+++ b/cmd/pint/lint.go
@@ -120,7 +120,6 @@ func actionLint(c *cli.Context) error {
 }
 
 func report(summary reporter.Summary, reporters *config.Reporters) error {
-
 	if reporters.JSON != nil {
 		r := reporter.NewJSONReporter(reporters.JSON.Path)
 		err := r.Submit(summary.Reports())

--- a/cmd/pint/lint.go
+++ b/cmd/pint/lint.go
@@ -120,10 +120,10 @@ func actionLint(c *cli.Context) error {
 }
 
 func report(summary reporter.Summary, reporters *config.Reporters) error {
-	if reporters != nil {
+	if reporters != nil && reporters.JSON != nil {
 		if reporters.JSON != nil {
 			r := reporter.NewJSONReporter(reporters.JSON.Path)
-			err := r.Submit(summary.Reports())
+			if err := r.Submit(summary.Reports()); err != nil { return err; }
 			if err != nil {
 				return err
 			}

--- a/cmd/pint/lint.go
+++ b/cmd/pint/lint.go
@@ -87,6 +87,11 @@ func actionLint(c *cli.Context) error {
 		return err
 	}
 
+	err = report(summary, meta.cfg.Reporters)
+	if err != nil {
+		return err
+	}
+
 	bySeverity := map[string]interface{}{} // interface{} is needed for log.Fields()
 	var problems, hiddenProblems, failProblems int
 	for s, c := range summary.CountBySeverity() {
@@ -111,6 +116,19 @@ func actionLint(c *cli.Context) error {
 	if failProblems > 0 {
 		return fmt.Errorf("found %d problem(s) with severity %s or higher", failProblems, failOn)
 	}
+	return nil
+}
+
+func report(summary reporter.Summary, reporters *config.Reporters) error {
+
+	if reporters.JSON != nil {
+		r := reporter.NewJSONReporter(reporters.JSON.Path)
+		err := r.Submit(summary.Reports())
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/cmd/pint/lint_test.go
+++ b/cmd/pint/lint_test.go
@@ -6,6 +6,8 @@ import (
 	"path"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func mockRules(dir string, filesCount, rulesPerFile int) error {
@@ -151,4 +153,33 @@ func BenchmarkLint(b *testing.B) {
 			b.FailNow()
 		}
 	}
+}
+
+func TestLintReporters(t *testing.T) {
+	var err error
+
+	rulesDir := t.TempDir()
+	err = mockRules(rulesDir, 1, 1)
+	require.NoError(t, err)
+	configPath := path.Join(rulesDir, ".pint.hcl")
+	err = mockConfig(configPath)
+	require.NoError(t, err)
+
+	json_file := path.Join(rulesDir, ".reporter.json")
+	content := fmt.Sprintf(`
+  parser {
+    relaxed = ["(.*)"]
+  }
+  
+  reporters {
+    json {
+      path = "%s"
+    }
+  }
+  `, strings.Replace(json_file, `\`, `\\`, -1))
+	os.WriteFile(configPath, []byte(content), 0o644)
+	app := newApp()
+	err = app.Run([]string{"pint", "-c", configPath, "-l", "error", "--offline", "lint", rulesDir + "/*.yaml"})
+	require.NoError(t, err)
+	require.FileExists(t, json_file)
 }

--- a/cmd/pint/lint_test.go
+++ b/cmd/pint/lint_test.go
@@ -155,7 +155,7 @@ func BenchmarkLint(b *testing.B) {
 	}
 }
 
-func TestLintReporters(t *testing.T) {
+func TestJSONLintReporter(t *testing.T) {
 	var err error
 
 	rulesDir := t.TempDir()
@@ -183,4 +183,26 @@ func TestLintReporters(t *testing.T) {
 	err = app.Run([]string{"pint", "-c", configPath, "-l", "error", "--offline", "lint", rulesDir + "/*.yaml"})
 	require.NoError(t, err)
 	require.FileExists(t, jsonFile)
+}
+
+func TestNoLintReporters(t *testing.T) {
+	var err error
+
+	rulesDir := t.TempDir()
+	err = mockRules(rulesDir, 1, 1)
+	require.NoError(t, err)
+	configPath := path.Join(rulesDir, ".pint.hcl")
+	err = mockConfig(configPath)
+	require.NoError(t, err)
+
+	content := `
+  parser {
+    relaxed = ["(.*)"]
+  }
+  `
+	err = os.WriteFile(configPath, []byte(content), 0o644)
+	require.NoError(t, err)
+	app := newApp()
+	err = app.Run([]string{"pint", "-c", configPath, "-l", "error", "--offline", "lint", rulesDir + "/*.yaml"})
+	require.NoError(t, err)
 }

--- a/cmd/pint/lint_test.go
+++ b/cmd/pint/lint_test.go
@@ -165,7 +165,7 @@ func TestLintReporters(t *testing.T) {
 	err = mockConfig(configPath)
 	require.NoError(t, err)
 
-	json_file := path.Join(rulesDir, ".reporter.json")
+	jsonFile := path.Join(rulesDir, ".reporter.json")
 	content := fmt.Sprintf(`
   parser {
     relaxed = ["(.*)"]
@@ -176,10 +176,11 @@ func TestLintReporters(t *testing.T) {
       path = "%s"
     }
   }
-  `, strings.Replace(json_file, `\`, `\\`, -1))
-	os.WriteFile(configPath, []byte(content), 0o644)
+  `, strings.ReplaceAll(jsonFile, `\`, `\\`))
+	err = os.WriteFile(configPath, []byte(content), 0o644)
+	require.NoError(t, err)
 	app := newApp()
 	err = app.Run([]string{"pint", "-c", configPath, "-l", "error", "--offline", "lint", rulesDir + "/*.yaml"})
 	require.NoError(t, err)
-	require.FileExists(t, json_file)
+	require.FileExists(t, jsonFile)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	Rules             []Rule                   `hcl:"rule,block" json:"rules,omitempty"`
 	Owners            *Owners                  `hcl:"owners,block" json:"owners,omitempty"`
 	PrometheusServers []*promapi.FailoverGroup `json:"-"`
+	Reporters         *Reporters               `hcl:"reporters,block" json:"reporters,omitempty"`
 }
 
 func (cfg *Config) DisableOnlineChecks() {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1373,6 +1373,7 @@ prometheus "prom3" {
 				checks.LabelsConflictCheckName + "(prom3)",
 			},
 		},
+		
 	}
 
 	dir := t.TempDir()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1373,7 +1373,6 @@ prometheus "prom3" {
 				checks.LabelsConflictCheckName + "(prom3)",
 			},
 		},
-		
 	}
 
 	dir := t.TempDir()

--- a/internal/config/json_reporter.go
+++ b/internal/config/json_reporter.go
@@ -1,0 +1,15 @@
+package config
+
+import "errors"
+
+type JSONReporterSettings struct {
+	Path string `hcl:"path" json:"path"`
+}
+
+func (ag JSONReporterSettings) validate() error {
+	if ag.Path == "" {
+		return errors.New("empty path")
+	}
+
+	return nil
+}

--- a/internal/config/json_reporter.go
+++ b/internal/config/json_reporter.go
@@ -6,8 +6,8 @@ type JSONReporterSettings struct {
 	Path string `hcl:"path" json:"path"`
 }
 
-func (ag JSONReporterSettings) validate() error {
-	if ag.Path == "" {
+func (settings JSONReporterSettings) validate() error {
+	if settings.Path == "" {
 		return errors.New("empty path")
 	}
 

--- a/internal/config/json_reporter_test.go
+++ b/internal/config/json_reporter_test.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestJSONReporterSettings(t *testing.T) {
+	type testCaseT struct {
+		conf JSONReporterSettings
+		err  error
+	}
+
+	testCases := []testCaseT{
+		{
+			conf: JSONReporterSettings{Path: "out.json"},
+		},
+		{
+			conf: JSONReporterSettings{},
+			err:  errors.New("empty path"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%v", tc.conf), func(t *testing.T) {
+			err := tc.conf.validate()
+			if err == nil || tc.err == nil {
+				require.Equal(t, err, tc.err)
+			} else {
+				require.EqualError(t, err, tc.err.Error())
+			}
+		})
+	}
+}

--- a/internal/config/reporters.go
+++ b/internal/config/reporters.go
@@ -1,0 +1,5 @@
+package config
+
+type Reporters struct {
+	JSON *JSONReporterSettings `hcl:"json,block" json:"json,omitempty"`
+}

--- a/internal/reporter/json.go
+++ b/internal/reporter/json.go
@@ -3,6 +3,8 @@ package reporter
 import (
 	"encoding/json"
 	"os"
+
+	"github.com/cloudflare/pint/internal/checks"
 )
 
 func NewJSONReporter(path string) JSONReporter {
@@ -14,19 +16,33 @@ type JSONReporter struct {
 }
 
 type JSONReport struct {
-	ReportedPath: string	`json:reportedPath`
-	SourcePath: string		`json:sourcePath`
-	Rule: struct {
-		Name: string		`json:name`
-		Type: string		`json:type`
+	ReportedPath string         `json:"reportedPath"`
+	SourcePath   string         `json:"sourcePath"`
+	Rule         JSONReportRule `json:"rule"`
+	Problem      checks.Problem `json:"problem"`
+	Owner        string         `json:"owner"`
+}
 
-	}						`json:rule`
-	Problem: checks.Problem	`json:problem`
-	Owner: stringchan		`json:owner`
+type JSONReportRule struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
 }
 
 func (cr JSONReporter) Submit(reports []Report) error {
-	result, err := json.Marshal(reports)
+	json_reports := make([]JSONReport, 0, len(reports))
+	for _, report := range reports {
+		json_reports = append(json_reports, JSONReport{
+			ReportedPath: report.ReportedPath,
+			SourcePath:   report.SourcePath,
+			Owner:        report.Owner,
+			Problem:      report.Problem,
+			Rule: JSONReportRule{
+				Name: report.Rule.Name(),
+				Type: string(report.Rule.Type()),
+			},
+		})
+	}
+	result, err := json.Marshal(json_reports)
 	if err != nil {
 		return err
 	}

--- a/internal/reporter/json.go
+++ b/internal/reporter/json.go
@@ -1,0 +1,40 @@
+package reporter
+
+import (
+	"encoding/json"
+	"os"
+)
+
+func NewJSONReporter(path string) JSONReporter {
+	return JSONReporter{path}
+}
+
+type JSONReporter struct {
+	path string
+}
+
+type JSONReport struct {
+	ReportedPath: string	`json:reportedPath`
+	SourcePath: string		`json:sourcePath`
+	Rule: struct {
+		Name: string		`json:name`
+		Type: string		`json:type`
+
+	}						`json:rule`
+	Problem: checks.Problem	`json:problem`
+	Owner: stringchan		`json:owner`
+}
+
+func (cr JSONReporter) Submit(reports []Report) error {
+	result, err := json.Marshal(reports)
+	if err != nil {
+		return err
+	}
+	f, err := os.Create(cr.path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.WriteString(string(result))
+	return err
+}

--- a/internal/reporter/json.go
+++ b/internal/reporter/json.go
@@ -29,9 +29,9 @@ type JSONReportRule struct {
 }
 
 func (cr JSONReporter) Submit(reports []Report) error {
-	json_reports := make([]JSONReport, 0, len(reports))
+	jsonReports := make([]JSONReport, 0, len(reports))
 	for _, report := range reports {
-		json_reports = append(json_reports, JSONReport{
+		jsonReports = append(jsonReports, JSONReport{
 			ReportedPath: report.ReportedPath,
 			SourcePath:   report.SourcePath,
 			Owner:        report.Owner,
@@ -42,7 +42,7 @@ func (cr JSONReporter) Submit(reports []Report) error {
 			},
 		})
 	}
-	result, err := json.Marshal(json_reports)
+	result, err := json.Marshal(jsonReports)
 	if err != nil {
 		return err
 	}

--- a/internal/reporter/json_test.go
+++ b/internal/reporter/json_test.go
@@ -1,15 +1,16 @@
 package reporter_test
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/cloudflare/pint/internal/checks"
 	"github.com/cloudflare/pint/internal/parser"
 	"github.com/cloudflare/pint/internal/reporter"
-	"github.com/stretchr/testify/require"
 )
 
 func TestJSONReporter(t *testing.T) {
@@ -36,14 +37,13 @@ func TestJSONReporter(t *testing.T) {
 	}
 	path := filepath.Join(t.TempDir(), "json-reporter-test.json")
 	defer os.Remove(path)
-	json_reporter := reporter.NewJSONReporter(path)
-	json_reporter.Submit(reports)
+	jsonReporter := reporter.NewJSONReporter(path)
+	require.NoError(t, jsonReporter.Submit(reports))
 	jsonFile, err := os.Open(path)
 	require.NoError(t, err, "Couldn't open reported json file")
 	defer jsonFile.Close()
-	byteValue, err := ioutil.ReadAll(jsonFile)
+	byteValue, err := io.ReadAll(jsonFile)
 	require.NoError(t, err, "Error reading json")
 	expected := "[{\"reportedPath\":\"\",\"sourcePath\":\"foo.txt\",\"rule\":{\"name\":\"sum errors\",\"type\":\"recording\"},\"problem\":{\"Fragment\":\"syntax error\",\"Lines\":[2],\"Reporter\":\"mock\",\"Text\":\"syntax error\",\"Severity\":3},\"owner\":\"\"}]"
 	require.Equal(t, expected, string(byteValue))
-
 }

--- a/internal/reporter/json_test.go
+++ b/internal/reporter/json_test.go
@@ -1,8 +1,6 @@
 package reporter_test
 
 import (
-	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -36,18 +34,16 @@ func TestJSONReporter(t *testing.T) {
 			},
 		},
 	}
-	path := filepath.Join(os.TempDir(), "json-reporter-test.json")
-	//defer os.Remove(path)
-	fmt.Println(path)
+	path := filepath.Join(t.TempDir(), "json-reporter-test.json")
+	defer os.Remove(path)
 	json_reporter := reporter.NewJSONReporter(path)
 	json_reporter.Submit(reports)
 	jsonFile, err := os.Open(path)
 	require.NoError(t, err, "Couldn't open reported json file")
 	defer jsonFile.Close()
-	byteValue, _ := ioutil.ReadAll(jsonFile)
-	var readReports []reporter.Report
-	err = json.Unmarshal(byteValue, &readReports)
-	require.NoError(t, err, "Error marshalling json")
-	require.Equal(t, reports, readReports)
+	byteValue, err := ioutil.ReadAll(jsonFile)
+	require.NoError(t, err, "Error reading json")
+	expected := "[{\"reportedPath\":\"\",\"sourcePath\":\"foo.txt\",\"rule\":{\"name\":\"sum errors\",\"type\":\"recording\"},\"problem\":{\"Fragment\":\"syntax error\",\"Lines\":[2],\"Reporter\":\"mock\",\"Text\":\"syntax error\",\"Severity\":3},\"owner\":\"\"}]"
+	require.Equal(t, expected, string(byteValue))
 
 }

--- a/internal/reporter/json_test.go
+++ b/internal/reporter/json_test.go
@@ -1,0 +1,53 @@
+package reporter_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cloudflare/pint/internal/checks"
+	"github.com/cloudflare/pint/internal/parser"
+	"github.com/cloudflare/pint/internal/reporter"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJSONReporter(t *testing.T) {
+	p := parser.NewParser()
+	mockRules, _ := p.Parse([]byte(`
+- record: target is down
+  expr: up == 0
+- record: sum errors
+  expr: sum(errors) by (job)
+`))
+	reports := []reporter.Report{
+		{
+			SourcePath:    "foo.txt",
+			ModifiedLines: []int{2},
+			Rule:          mockRules[1],
+			Problem: checks.Problem{
+				Fragment: "syntax error",
+				Lines:    []int{2},
+				Reporter: "mock",
+				Text:     "syntax error",
+				Severity: checks.Fatal,
+			},
+		},
+	}
+	path := filepath.Join(os.TempDir(), "json-reporter-test.json")
+	//defer os.Remove(path)
+	fmt.Println(path)
+	json_reporter := reporter.NewJSONReporter(path)
+	json_reporter.Submit(reports)
+	jsonFile, err := os.Open(path)
+	require.NoError(t, err, "Couldn't open reported json file")
+	defer jsonFile.Close()
+	byteValue, _ := ioutil.ReadAll(jsonFile)
+	var readReports []reporter.Report
+	err = json.Unmarshal(byteValue, &readReports)
+	require.NoError(t, err, "Error marshalling json")
+	require.Equal(t, reports, readReports)
+
+}


### PR DESCRIPTION
Adds the ability to define (in config) reporters. Adds a JSON reporter to write lint results to disk in JSON format.

Config:
```
reporters {
    json {
      path = "/tmp/pint.report.json"
    }
  }
```