### PR TITLE
Overrides severity Marshalling

### DIFF
--- a/internal/checks/base.go
+++ b/internal/checks/base.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"encoding/json"
 
 	"github.com/cloudflare/pint/internal/discovery"
 	"github.com/cloudflare/pint/internal/parser"
@@ -76,6 +77,10 @@ func ParseSeverity(s string) (Severity, error) {
 	default:
 		return Fatal, fmt.Errorf("unknown severity: %s", s)
 	}
+}
+
+func (s Severity) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.String())
 }
 
 const (

--- a/internal/checks/base.go
+++ b/internal/checks/base.go
@@ -2,9 +2,9 @@ package checks
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
-	"encoding/json"
 
 	"github.com/cloudflare/pint/internal/discovery"
 	"github.com/cloudflare/pint/internal/parser"

--- a/internal/reporter/json_test.go
+++ b/internal/reporter/json_test.go
@@ -44,6 +44,6 @@ func TestJSONReporter(t *testing.T) {
 	defer jsonFile.Close()
 	byteValue, err := io.ReadAll(jsonFile)
 	require.NoError(t, err, "Error reading json")
-	expected := "[{\"reportedPath\":\"\",\"sourcePath\":\"foo.txt\",\"rule\":{\"name\":\"sum errors\",\"type\":\"recording\"},\"problem\":{\"Fragment\":\"syntax error\",\"Lines\":[2],\"Reporter\":\"mock\",\"Text\":\"syntax error\",\"Severity\":3},\"owner\":\"\"}]"
+	expected := "[{\"reportedPath\":\"\",\"sourcePath\":\"foo.txt\",\"rule\":{\"name\":\"sum errors\",\"type\":\"recording\"},\"problem\":{\"Fragment\":\"syntax error\",\"Lines\":[2],\"Reporter\":\"mock\",\"Text\":\"syntax error\",\"Severity\":\"Fatal\"},\"owner\":\"\"}]"
 	require.Equal(t, expected, string(byteValue))
 }


### PR DESCRIPTION
Adds Marshalling for severity as a string. Tested with the json reporter test.