### PR TITLE
Refine counter check

### DIFF
--- a/docs/checks/promql/counter.md
+++ b/docs/checks/promql/counter.md
@@ -13,7 +13,7 @@ A counter should be wrapped by one of the following operators/functions:
 - `rate`, `irate`, `increase` - [performing rate calculations while handling counter resets](https://promlabs.com/blog/2021/01/29/how-exactly-does-promql-calculate-rates/)
   - Note: [`irate` is excluded from alerting rules](https://www.robustperception.io/avoid-irate-in-alerts/).  
 - `count`, `count_over_time`, `absent`, `absent_over_time`, `present_over_time`, `count_values` - these are common and valid use cases of any raw metric
-- `or`, `unless` - only if the counter is on the right hand side of the operator as we are retrieving the labels rather than the value of the counter
+- `or`, `unless` - only if the counter is on the right hand side of the operator. In those cases, we are retrieving the labels rather than the value of the counter
 
 ## Common problems
 

--- a/docs/checks/promql/counter.md
+++ b/docs/checks/promql/counter.md
@@ -8,11 +8,12 @@ grand_parent: Documentation
 
 This check inspects counter metrics used in queries to verify that the raw counter value is not used in calculations.
 
-A counter should be wrapped by one of the following functions:
+A counter should be wrapped by one of the following operators/functions:
 
 - `rate`, `irate`, `increase` - [performing rate calculations while handling counter resets](https://promlabs.com/blog/2021/01/29/how-exactly-does-promql-calculate-rates/)
   - Note: [`irate` is excluded from alerting rules](https://www.robustperception.io/avoid-irate-in-alerts/).  
-- `count`, `count_over_time`, `absent`, `absent_over_time`, `present_over_time` - these are common and valid use cases of any raw metric
+- `count`, `count_over_time`, `absent`, `absent_over_time`, `present_over_time`, `count_values` - these are common and valid use cases of any raw metric
+- `or`, `unless` - only if the counter is on the right hand side of the operator as we are retrieving the labels rather than the value of the counter
 
 ## Common problems
 

--- a/internal/checks/promql_counter.go
+++ b/internal/checks/promql_counter.go
@@ -132,15 +132,15 @@ func (c CounterCheck) checkNode(ctx context.Context, node *parser.PromQLNode, en
 		for _, child := range node.Children {
 			isLHS := n.LHS.String() == child.Expr
 			if isLHS {
-				problems = append(problems, c.checkNode(ctx, child, entries, false, isAlertRule, isCounterMap)...)
+				parentUsesAllowedFunction = false
 			} else {
-				problems = append(problems, c.checkNode(ctx, child, entries, true, isAlertRule, isCounterMap)...)
+				parentUsesAllowedFunction = true
 			}
+			problems = append(problems, c.checkNode(ctx, child, entries, parentUsesAllowedFunction, isAlertRule, isCounterMap)...)
 		}
 	} else {
 		for _, child := range node.Children {
 			problems = append(problems, c.checkNode(ctx, child, entries, parentUsesAllowedFunction, isAlertRule, isCounterMap)...)
-
 		}
 	}
 	return problems


### PR DESCRIPTION
## Changes
Make minor fixes to the promql/counter check to include more valid use cases where the raw counter value is not directly used. 
- allow raw counter to be used on the RHS of `or` and `unless` (the RHS does not affect the returned time series)
- allow raw counters to be wrapped by operators: `count` and `count_values`   